### PR TITLE
Android 14 foreground service crash fix

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -18,13 +18,6 @@
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>
         </receiver>
-        <service
-            android:name="com.jwplayer.pub.api.background.MediaService"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MEDIA_BUTTON" />
-            </intent-filter>
-        </service>
     </application>
 
 </manifest>


### PR DESCRIPTION
Removing `com.jwplayer.pub.api.background.MediaService` from AndroidManifest to avoid foreground services handling crash.